### PR TITLE
Capitalize Python.h

### DIFF
--- a/mdpcl.py
+++ b/mdpcl.py
@@ -49,7 +49,7 @@ else:
 # define useful constants
 
 C0 = """
-#include "python.h"
+#include "Python.h"
 #if PY_MAJOR_VERSION >= 3
 #define IS_PY3K
 #endif


### PR DESCRIPTION
I had to capitalize the "p" in the Python header include. This probably works fine as is on Mac OS, but it wouldn't compile the C99 version for me on Ubuntu 12.10.
